### PR TITLE
Fixed handling urls with query params

### DIFF
--- a/web/packages/ra-theme/src/components/index.tsx
+++ b/web/packages/ra-theme/src/components/index.tsx
@@ -46,8 +46,9 @@ import Favicon from "../img/favicon.png";
  */
 
 function Theme() {
-  const { state, actions } = useConnect<Packages>();
-  const data = state.source.get(state.router.link);
+  const { state, actions, libraries } = useConnect<Packages>();
+  const { route } = libraries.source.parse(state.router.link);
+  const data = state.source.get(route);
 
   /**
    * Things related to playing audio (needs to be global)

--- a/web/packages/ra-theme/src/handlers/page.ts
+++ b/web/packages/ra-theme/src/handlers/page.ts
@@ -83,6 +83,8 @@ const pageHandler =
       route: route,
       query,
       isPage: true,
+      isReady: true,
+      isFetching: false,
     }); // This ensures the resulting type is correct.
 
     // Overwrite properties if the request is a preview.

--- a/web/packages/ra-theme/src/handlers/postType.ts
+++ b/web/packages/ra-theme/src/handlers/postType.ts
@@ -112,6 +112,8 @@ const postTypeHandler =
       query,
       isPostType: true,
       [`is${capitalize(data.type)}`]: true,
+      isReady: true,
+      isFetching: false,
     }); // This ensures the resulting type is correct.
 
     // Overwrite properties if the request is a preview.

--- a/web/packages/ra-theme/src/handlers/postTypeArchive.ts
+++ b/web/packages/ra-theme/src/handlers/postTypeArchive.ts
@@ -109,7 +109,7 @@ const postTypeArchiveHandler =
     const hasOlderPosts = page > 1;
 
     // 5. add data to source
-    const currentPageData = state.source.data[link];
+    const currentPageData = state.source.get(route);
 
     const newPageData = {
       type,
@@ -119,6 +119,8 @@ const postTypeArchiveHandler =
       isArchive: true,
       isPostTypeArchive: true,
       [`is${capitalize(type)}Archive`]: true,
+      isReady: true,
+      isFetching: false,
 
       // Add next and previous if they exist.
       ...(hasOlderPosts && {

--- a/web/packages/ra-theme/src/index.ts
+++ b/web/packages/ra-theme/src/index.ts
@@ -192,7 +192,7 @@ const raThemeTypeScript: RaThemeTypeScript = {
           libraries.source.handlers.push({
             name: `${key} archive handler`,
             priority: 5,
-            pattern: `${ensurePath(data.archivePath)}`,
+            pattern: ensurePath(data.archivePath),
             func: postTypeArchiveHandler({
               type: key,
               endpoint: data.endpoint,


### PR DESCRIPTION
Now it works when any query params (e.g. `?foo=bar`) are appended to urls.